### PR TITLE
Update dcservo.ino

### DIFF
--- a/dcservo.ino
+++ b/dcservo.ino
@@ -130,8 +130,8 @@ ISR (PCINT0_vect) { // handle pin change interrupt for D8
   encoder0Pos+= QEM [Old * 4 + New];
 
   // endstop detection.  it is interlocked.  under normal operation it would not
-  // send a digital write, just on transition between smaller or equal to 0 and not 0;
-  // this would not significantly affect normal operation
+  // send a digital write, just on transition between smaller than 2;
+  // this would not significantly affect normal operation. 
   if(encoder0Pos<2)
     {
       if(encoder0Pos<=0&&!isHome)  

--- a/dcservo.ino
+++ b/dcservo.ino
@@ -132,7 +132,9 @@ ISR (PCINT0_vect) { // handle pin change interrupt for D8
   // endstop detection.  it is interlocked.  under normal operation it would not
   // send a digital write, just on transition between smaller or equal to 0 and not 0;
   // this would not significantly affect normal operation
-  if(encoder0Pos<=0&&!isHome)  
+  if(encoder0Pos<2)
+    {
+      if(encoder0Pos<=0&&!isHome)  
       {
         isHome=true; 
         digitalWrite(ENDSTOP,isHome);
@@ -142,6 +144,7 @@ ISR (PCINT0_vect) { // handle pin change interrupt for D8
         isHome=false; 
         digitalWrite(ENDSTOP,isHome);
       }
+    }
 
 }
 
@@ -151,9 +154,11 @@ void encoderInt() { // handle pin change interrupt for D2
   encoder0Pos+= QEM [Old * 4 + New];
 
   // endstop detection.  it is interlocked.  under normal operation it would not
-  // send a digital write, just on transition between smaller or equal to 0 and not 0;
-  // this would not significantly affect normal operation
-  if(encoder0Pos<=0&&!isHome)  
+  // send a digital write, just on transition between smaller than 2;
+  // this would not significantly affect normal operation. 
+  if(encoder0Pos<2)
+    {
+      if(encoder0Pos<=0&&!isHome)  
       {
         isHome=true; 
         digitalWrite(ENDSTOP,isHome);
@@ -163,6 +168,7 @@ void encoderInt() { // handle pin change interrupt for D2
         isHome=false; 
         digitalWrite(ENDSTOP,isHome);
       }
+    }
 }
 
 


### PR DESCRIPTION
fixed conflict with ENDSTOP pin was 3 but now is 4 this was a conflict with the step input
assert the ENDSTOP pin only in the pin change interrupt and only if the change is between greater than 0 or 0 and less
digitalWrite is not used during normal operation. so it does not affect the main loop
when option A is true, home / not home is indicated at the end of the stream